### PR TITLE
SG-11051 Add column mapping support and multi-target delta merge handler

### DIFF
--- a/spark-core/src/main/scala/com/intuit/data/simplan/spark/core/delta/DeltaMergeUtils.scala
+++ b/spark-core/src/main/scala/com/intuit/data/simplan/spark/core/delta/DeltaMergeUtils.scala
@@ -41,7 +41,11 @@ object DeltaMergeUtils {
         matchConditions.foldLeft(deltaMergeBuilder) { (z, f) =>
           {
             f.action match {
-              case "UPDATE" => z.whenMatched(f.expression).updateAll()
+              case "UPDATE" =>
+                f.columnMappings match {
+                  case Some(mappings) => z.whenMatched(f.expression).updateExpr(mappings)
+                  case None           => z.whenMatched(f.expression).updateAll()
+                }
               case "DELETE" => z.whenMatched(f.expression).delete()
               case _        => throw new Exception("UnSupported Type")
             }
@@ -54,7 +58,11 @@ object DeltaMergeUtils {
         notMatchConditions.foldLeft(matchDeltaMergeBuilder) { (z, f) =>
           {
             f.action match {
-              case "INSERT" => z.whenNotMatched(f.expression).insertAll()
+              case "INSERT" =>
+                f.columnMappings match {
+                  case Some(mappings) => z.whenNotMatched(f.expression).insertExpr(mappings)
+                  case None           => z.whenNotMatched(f.expression).insertAll()
+                }
               case _        => throw new Exception("UnSupported Type")
             }
           }

--- a/spark-core/src/main/scala/com/intuit/data/simplan/spark/core/domain/operator/config/transformations/DeltaMergeConfig.scala
+++ b/spark-core/src/main/scala/com/intuit/data/simplan/spark/core/domain/operator/config/transformations/DeltaMergeConfig.scala
@@ -14,4 +14,4 @@ case class DeltaMergeConfig(
     notMatchCondition: Seq[Condition]
 ) extends OperatorConfig
 
-case class Condition(expression: String, action: String)
+case class Condition(expression: String, action: String, columnMappings: Option[Map[String, String]] = None)

--- a/spark-core/src/main/scala/com/intuit/data/simplan/spark/core/handlers/foreachbatch/MultipleDeltaMergeForEachBatchHandler.scala
+++ b/spark-core/src/main/scala/com/intuit/data/simplan/spark/core/handlers/foreachbatch/MultipleDeltaMergeForEachBatchHandler.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intuit.data.simplan.spark.core.handlers.foreachbatch
+
+import com.intuit.data.simplan.global.utils.SimplanImplicits.FromJsonImplicits
+import com.intuit.data.simplan.spark.core.context.SparkAppContext
+import com.intuit.data.simplan.spark.core.delta.DeltaMergeUtils
+import com.intuit.data.simplan.spark.core.domain.SparkOperatorRequest
+import com.intuit.data.simplan.spark.core.domain.operator.config.transformations.DeltaMergeConfig
+import io.delta.tables.DeltaTable
+import org.apache.spark.sql.DataFrame
+
+case class MultipleDeltaMergeConfig(merges: Seq[DeltaMergeConfig], cacheBatch: Boolean = true)
+
+class MultipleDeltaMergeForEachBatchHandler(sparkAppContext: SparkAppContext) extends ForEachBatchHandler(sparkAppContext) {
+
+  override def handle(request: SparkOperatorRequest, handlerConfigJson: String): (DataFrame, Long) => Unit = {
+    val config: MultipleDeltaMergeConfig = handlerConfigJson.fromJson[MultipleDeltaMergeConfig]
+
+    val mergeSpecs: Seq[(DeltaTable, DeltaMergeConfig)] = config.merges.map { mergeConfig =>
+      val deltaTable = request.deltaTable(mergeConfig.deltaTableSource)
+      (deltaTable, mergeConfig)
+    }
+
+    (batchDF: DataFrame, batchId: Long) => {
+      if (config.cacheBatch) batchDF.cache()
+      try {
+        mergeSpecs.foreach { case (deltaTable, mergeConfig) =>
+          val builder = DeltaMergeUtils.createDeltaMergeBuilder(deltaTable, batchDF, mergeConfig)
+          builder.execute()
+        }
+      } finally {
+        if (config.cacheBatch) batchDF.unpersist()
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Support optional columnMappings on Condition to use updateExpr/insertExpr instead of updateAll/insertAll in DeltaMergeUtils
- Add MultipleDeltaMergeForEachBatchHandler to merge a single streaming batch into multiple Delta tables, with optional batch caching